### PR TITLE
Improve RSS diff generator

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -33310,8 +33310,23 @@ async function tweetRssDiff(rssPaths2, twitterTokens2) {
   const parser = new import_rss_parser.default();
   const oldRss = await parseRss(parser, rssPaths2.oldRssPath);
   const newRss = await parseRss(parser, rssPaths2.newRssPath);
-  const oldEntries = new Set(oldRss.items.map((item) => item.link));
-  const posts = newRss.items.filter((item) => !oldEntries.has(item.link)).map((entry) => `${entry.title} ${entry.link}`);
+  const oldIdent = oldRss.items.map(generateIdents).reduce(
+    (acc, idents) => {
+      Object.entries(idents).forEach(
+        ([key, value]) => value && acc[key].add(value)
+      );
+      return acc;
+    },
+    {
+      dateLinkIdents: /* @__PURE__ */ new Set(),
+      dateTitleIdents: /* @__PURE__ */ new Set()
+    }
+  );
+  const posts = newRss.items.filter((item) => {
+    return Object.entries(generateIdents(item)).every(
+      ([key, value]) => !oldIdent[key].has(value)
+    );
+  }).map((entry) => `${entry.title} ${entry.link}`);
   if (posts.length === 0) {
     core2.info("No new entry found.");
     return;
@@ -33331,6 +33346,16 @@ async function tweetRssDiff(rssPaths2, twitterTokens2) {
 async function parseRss(parser, filePath) {
   const data = import_fs.default.readFileSync(filePath, "utf8");
   return await parser.parseString(data);
+}
+function generateIdents(item) {
+  const date = item.pubDate && new Date(item.pubDate);
+  const dateString = date ? date.toDateString() : "";
+  const result = {};
+  if (typeof item.link === "string") {
+    result.dateLinkIdents = `${dateString};;;${item.link}`;
+  }
+  result.dateTitleIdents = `${dateString};;;${item.title}`;
+  return result;
 }
 
 // src/index.ts

--- a/dist/index.js
+++ b/dist/index.js
@@ -33310,10 +33310,13 @@ async function tweetRssDiff(rssPaths2, twitterTokens2) {
   const parser = new import_rss_parser.default();
   const oldRss = await parseRss(parser, rssPaths2.oldRssPath);
   const newRss = await parseRss(parser, rssPaths2.newRssPath);
-  const oldIdent = oldRss.items.map(generateIdents).reduce((acc, idents) => {
-    idents.forEach((ident) => acc.add(ident));
-    return acc;
-  }, /* @__PURE__ */ new Set(["Void"]));
+  const oldIdent = oldRss.items.map(generateIdents).reduce(
+    (acc, idents) => {
+      idents.forEach((ident) => acc.add(ident));
+      return acc;
+    },
+    /* @__PURE__ */ new Set(["Void"])
+  );
   const posts = newRss.items.filter((item) => {
     return !generateIdents(item).some((ident) => oldIdent.has(ident));
   }).map((entry) => `${entry.title} ${entry.link}`);
@@ -33338,13 +33341,12 @@ async function parseRss(parser, filePath) {
   return await parser.parseString(data);
 }
 function generateIdents(item) {
-  const date = item.pubDate && new Date(item.pubDate);
-  const dateString = date ? date.toDateString() : "";
   const result = [];
-  if (typeof item.link === "string") {
+  const dateString = item.pubDate && new Date(item.pubDate).toDateString();
+  if (dateString && typeof item.link === "string") {
     result.push(`DateLink;;;${dateString};;;${item.link}`);
   }
-  if (typeof item.title === "string") {
+  if (dateString && typeof item.title === "string") {
     result.push(`DateTitle;;;${dateString};;;${item.title}`);
   }
   if (typeof item.link === "string" && typeof item.title === "string") {

--- a/dist/index.js
+++ b/dist/index.js
@@ -19730,10 +19730,10 @@ Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
       (0, command_1.issueCommand)("error", (0, utils_1.toCommandProperties)(properties), message instanceof Error ? message.toString() : message);
     }
     exports2.error = error;
-    function warning(message, properties = {}) {
+    function warning2(message, properties = {}) {
       (0, command_1.issueCommand)("warning", (0, utils_1.toCommandProperties)(properties), message instanceof Error ? message.toString() : message);
     }
-    exports2.warning = warning;
+    exports2.warning = warning2;
     function notice(message, properties = {}) {
       (0, command_1.issueCommand)("notice", (0, utils_1.toCommandProperties)(properties), message instanceof Error ? message.toString() : message);
     }
@@ -33315,10 +33315,15 @@ async function tweetRssDiff(rssPaths2, twitterTokens2) {
       idents.forEach((ident) => acc.add(ident));
       return acc;
     },
-    /* @__PURE__ */ new Set(["Void"])
+    /* @__PURE__ */ new Set()
   );
   const posts = newRss.items.filter((item) => {
-    return !generateIdents(item).some((ident) => oldIdent.has(ident));
+    const idents = generateIdents(item);
+    if (idents.length === 0) {
+      core2.warning(`Skipping entry with no identifiers: ${item.title} ${item.link}`);
+      return false;
+    }
+    return !idents.some((ident) => oldIdent.has(ident));
   }).map((entry) => `${entry.title} ${entry.link}`);
   if (posts.length === 0) {
     core2.info("No new entry found.");
@@ -33351,9 +33356,6 @@ function generateIdents(item) {
   }
   if (typeof item.link === "string" && typeof item.title === "string") {
     result.push(`LinkTitle;;;${item.link};;;${item.title}`);
-  }
-  if (result.length === 0) {
-    result.push("Void");
   }
   return result;
 }

--- a/src/twitter.ts
+++ b/src/twitter.ts
@@ -15,10 +15,13 @@ export async function tweetRssDiff(
   const oldRss = await parseRss(parser, rssPaths.oldRssPath);
   const newRss = await parseRss(parser, rssPaths.newRssPath);
 
-  const oldIdent = oldRss.items.map(generateIdents).reduce((acc, idents) => {
-    idents.forEach((ident) => acc.add(ident));
-    return acc;
-  }, new Set<string>(["Void"]));
+  const oldIdent = oldRss.items.map(generateIdents).reduce(
+    (acc, idents) => {
+      idents.forEach((ident) => acc.add(ident));
+      return acc;
+    },
+    new Set<string>(["Void"]),
+  );
 
   const posts = newRss.items
     .filter((item) => {
@@ -64,15 +67,13 @@ async function parseRss(parser: Parser, filePath: string): Promise<RssData> {
  * @returns An object containing identifiers based on the item's publication date, link, and title.
  */
 function generateIdents(item: Item): string[] {
-  const date = item.pubDate && new Date(item.pubDate);
-  const dateString = date ? date.toDateString() : "";
-
   const result = [];
 
-  if (typeof item.link === "string") {
+  const dateString = item.pubDate && new Date(item.pubDate).toDateString();
+  if (dateString && typeof item.link === "string") {
     result.push(`DateLink;;;${dateString};;;${item.link}`);
   }
-  if (typeof item.title === "string") {
+  if (dateString && typeof item.title === "string") {
     result.push(`DateTitle;;;${dateString};;;${item.title}`);
   }
   if (typeof item.link === "string" && typeof item.title === "string") {

--- a/src/twitter.ts
+++ b/src/twitter.ts
@@ -15,27 +15,31 @@ export async function tweetRssDiff(
   const oldRss = await parseRss(parser, rssPaths.oldRssPath);
   const newRss = await parseRss(parser, rssPaths.newRssPath);
 
-  const oldIdent = oldRss.items.map(generateIdents).reduce(
-    (acc, idents) => {
-      idents.forEach((ident) => acc.add(ident));
-      return acc;
-    },
-    new Set<string>(),
-  );
+  const posts = [];
+  for (const entry of newRss.items) {
+    if (!entry.link) {
+      core.warning(`Entry with title "${entry.title}" has no link.`);
+      continue;
+    }
 
-  const posts = newRss.items
-    .filter((item) => {
-      const idents = generateIdents(item);
-      if (idents.length === 0) {
-        // Skip entries with no identifiers. They can't be compared.
-        core.warning(`Skipping entry with no identifiers: ${item.title} ${item.link}`);
-        return false;
-      }
+    const isOldEntry = oldRss.items.some((oldEntry) => {
+      const diffs = [
+        oldEntry.title !== entry.title,
+        oldEntry.link !== entry.link,
+        oldEntry.pubDate !== entry.pubDate,
+      ].filter((d) => d).length;
 
-      // Check if the item is new by comparing identifiers.
-      return !idents.some((ident) => oldIdent.has(ident));
-    })
-    .map((entry) => `${entry.title} ${entry.link}`);
+      return diffs <= 1;
+    });
+    if (isOldEntry) {
+      // Since ew entries are always at the top of the feed,
+      // we can stop checking if we reach an old entry.
+      break;
+    }
+
+    posts.push(`${entry.title} ${entry.link}`);
+  }
+
   if (posts.length === 0) {
     core.info("No new entry found.");
     return;
@@ -65,27 +69,4 @@ type RssData = Parser.Output<{}>;
 async function parseRss(parser: Parser, filePath: string): Promise<RssData> {
   const data = fs.readFileSync(filePath, "utf8");
   return await parser.parseString(data);
-}
-
-/**
- * Generates an identifier object for a given RSS feed item.
- *
- * @param item - The RSS feed item for which to generate identifiers.
- * @returns An object containing identifiers based on the item's publication date, link, and title.
- */
-function generateIdents(item: Item): string[] {
-  const result = [];
-
-  const dateString = item.pubDate && new Date(item.pubDate).toDateString();
-  if (dateString && typeof item.link === "string") {
-    result.push(`DateLink;;;${dateString};;;${item.link}`);
-  }
-  if (dateString && typeof item.title === "string") {
-    result.push(`DateTitle;;;${dateString};;;${item.title}`);
-  }
-  if (typeof item.link === "string" && typeof item.title === "string") {
-    result.push(`LinkTitle;;;${item.link};;;${item.title}`);
-  }
-
-  return result;
 }

--- a/src/twitter.ts
+++ b/src/twitter.ts
@@ -29,10 +29,11 @@ export async function tweetRssDiff(
         oldEntry.pubDate !== entry.pubDate,
       ].filter((d) => d).length;
 
+      // If there are more than 1 difference, we assume it's a different entry.
       return diffs <= 1;
     });
     if (isOldEntry) {
-      // Since ew entries are always at the top of the feed,
+      // Since new entries are always at the top of the feed,
       // we can stop checking if we reach an old entry.
       break;
     }

--- a/src/twitter.ts
+++ b/src/twitter.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import { setTimeout } from "timers/promises";
-import Parser from "rss-parser";
+import Parser, { type Item } from "rss-parser";
 import { TwitterApi, type TwitterApiTokens } from "twitter-api-v2";
 import * as core from "@actions/core";
 
@@ -15,10 +15,25 @@ export async function tweetRssDiff(
   const oldRss = await parseRss(parser, rssPaths.oldRssPath);
   const newRss = await parseRss(parser, rssPaths.newRssPath);
 
-  const oldEntries = new Set(oldRss.items.map((item) => item.link));
+  const oldIdent = oldRss.items.map(generateIdents).reduce(
+    (acc, idents) => {
+      Object.entries(idents).forEach(
+        ([key, value]) => value && acc[key as keyof Identifier].add(value),
+      );
+      return acc;
+    },
+    {
+      dateLinkIdents: new Set(),
+      dateTitleIdents: new Set(),
+    },
+  );
 
   const posts = newRss.items
-    .filter((item) => !oldEntries.has(item.link))
+    .filter((item) => {
+      return Object.entries(generateIdents(item)).every(
+        ([key, value]) => !oldIdent[key as keyof Identifier].has(value),
+      );
+    })
     .map((entry) => `${entry.title} ${entry.link}`);
   if (posts.length === 0) {
     core.info("No new entry found.");
@@ -49,4 +64,30 @@ type RssData = Parser.Output<{}>;
 async function parseRss(parser: Parser, filePath: string): Promise<RssData> {
   const data = fs.readFileSync(filePath, "utf8");
   return await parser.parseString(data);
+}
+
+
+interface Identifier {
+  dateLinkIdents?: string;
+  dateTitleIdents?: string;
+}
+
+/**
+ * Generates an identifier object for a given RSS feed item.
+ *
+ * @param item - The RSS feed item for which to generate identifiers.
+ * @returns An object containing identifiers based on the item's publication date, link, and title.
+ */
+function generateIdents(item: Item): Identifier {
+  const date = item.pubDate && new Date(item.pubDate);
+  const dateString = date ? date.toDateString() : "";
+
+  const result: Identifier = {};
+
+  if (typeof item.link === "string") {
+    result.dateLinkIdents = `${dateString};;;${item.link}`;
+  }
+  result.dateTitleIdents = `${dateString};;;${item.title}`;
+
+  return result;
 }

--- a/test/new.xml
+++ b/test/new.xml
@@ -20,8 +20,24 @@
     <item>
       <title>Third Entry</title>
       <link>http://www.example.com/third-entry</link>
-      <description>This is the third entry in the test RSS feed</description>
+      <description>New entry that should be tweeted</description>
       <pubDate>Tue, 12 Nov 2024 00:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>Fourth Entry</title>
+      <link>http://www.example.com/second-entry</link>
+      <description>This is the update of second entry. This should be tweeted.</description>
+      <pubDate>Wed, 20 Nov 2024 00:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>Second Entry</title>
+      <link>http://www.example.com/second-entry</link>
+      <description>This is almost same entry as second entry, except for pubDate. This should not be tweeted.</description>
+      <pubDate>Wed, 20 Nov 2024 00:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>Void</title>
+      <description>A void that should not be tweeted</description>
     </item>
   </channel>
 </rss>

--- a/test/new.xml
+++ b/test/new.xml
@@ -9,7 +9,7 @@
       <title>Fifth Entry</title>
       <link>http://www.example.com/second-entry</link>
       <description>New entry that should be tweeted, even though the link is the same as second entry.</description>
-      <pubDate>Fri, 01 Nov 2024 00:00:00 GMT</pubDate>
+      <pubDate>Wed, 13 Nov 2024 00:00:00 GMT</pubDate>
     </item>
     <item>
       <title>Fourth Entry</title>

--- a/test/new.xml
+++ b/test/new.xml
@@ -6,10 +6,16 @@
     <language>en-us</language>
     <atom:link href="https://www.example.com/rss.xml" rel="self" type="application/rss+xml"/>
     <item>
-      <title>First Entry</title>
-      <link>http://www.example.com/first-entry</link>
-      <description>This is the first entry in the test RSS feed</description>
-      <pubDate>Fri, 25 Oct 2024 00:00:00 GMT</pubDate>
+      <title>Fifth Entry</title>
+      <link>http://www.example.com/second-entry</link>
+      <description>New entry that should be tweeted, even though the link is the same as second entry.</description>
+      <pubDate>Fri, 01 Nov 2024 00:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>Fourth Entry</title>
+      <link>http://www.example.com/fourth-entry</link>
+      <description>New entry that should be tweeted</description>
+      <pubDate>Tue, 12 Nov 2024 00:00:00 GMT</pubDate>
     </item>
     <item>
       <title>Second Entry</title>
@@ -20,24 +26,14 @@
     <item>
       <title>Third Entry</title>
       <link>http://www.example.com/third-entry</link>
-      <description>New entry that should be tweeted</description>
-      <pubDate>Tue, 12 Nov 2024 00:00:00 GMT</pubDate>
+      <description>Since this is after the old entry, this should not be tweeted.</description>
+      <pubDate>Fri, 01 Nov 2024 00:00:00 GMT</pubDate>
     </item>
     <item>
-      <title>Fourth Entry</title>
-      <link>http://www.example.com/second-entry</link>
-      <description>This is the update of second entry. This should be tweeted.</description>
-      <pubDate>Wed, 20 Nov 2024 00:00:00 GMT</pubDate>
-    </item>
-    <item>
-      <title>Second Entry</title>
-      <link>http://www.example.com/second-entry</link>
-      <description>This is almost same entry as second entry, except for pubDate. This should not be tweeted.</description>
-      <pubDate>Wed, 20 Nov 2024 00:00:00 GMT</pubDate>
-    </item>
-    <item>
-      <title>Void</title>
-      <description>A void that should not be tweeted</description>
+      <title>First Entry</title>
+      <link>http://www.example.com/first-entry</link>
+      <description>This is the first entry in the test RSS feed</description>
+      <pubDate>Fri, 25 Oct 2024 00:00:00 GMT</pubDate>
     </item>
   </channel>
 </rss>

--- a/test/new.xml
+++ b/test/new.xml
@@ -27,7 +27,7 @@
       <title>Third Entry</title>
       <link>http://www.example.com/third-entry</link>
       <description>Since this is after the old entry, this should not be tweeted.</description>
-      <pubDate>Fri, 01 Nov 2024 00:00:00 GMT</pubDate>
+      <pubDate>Tue, 05 Nov 2024 00:00:00 GMT</pubDate>
     </item>
     <item>
       <title>First Entry</title>

--- a/test/old.xml
+++ b/test/old.xml
@@ -6,16 +6,16 @@
     <language>en-us</language>
     <atom:link href="https://www.example.com/rss.xml" rel="self" type="application/rss+xml"/>
     <item>
-      <title>First Entry</title>
-      <link>http://www.example.com/first-entry</link>
-      <description>This is the first entry in the test RSS feed</description>
-      <pubDate>Fri, 25 Oct 2024 00:00:00 GMT</pubDate>
-    </item>
-    <item>
       <title>Second Entry</title>
       <link>http://www.example.com/second-entry</link>
       <description>This is the second entry in the test RSS feed</description>
       <pubDate>Fri, 01 Nov 2024 00:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>First Entry</title>
+      <link>http://www.example.com/first-entry</link>
+      <description>This is the first entry in the test RSS feed</description>
+      <pubDate>Fri, 25 Oct 2024 00:00:00 GMT</pubDate>
     </item>
   </channel>
 </rss>


### PR DESCRIPTION
RSSフィードのエントリを投稿する条件を，

- リンクが一致するエントリがOLD_RSSに存在しないこと

から，

- フィードの先頭にあり，かつ
- 公開日・タイトル・リンクのうち，少なくとも2要素が一致するエントリがOLD_RSSに存在しないこと

に変更しました．